### PR TITLE
Simple Usability Tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     }
 
     button {
-      width: 150px;
+      min-width: 150px;
       height: 30px;
       margin-top: 30px;
       font-size: 15px;
@@ -57,10 +57,12 @@
     }
 
     button.comparison-button {
-      min-height: 70px;
+      min-height: 160px;
+      width: 240px;
       font-size: 22px;
       margin-top: 20px;
       height: initial;
+      padding: 14px;
     }
 
     button.active {

--- a/index.html
+++ b/index.html
@@ -148,8 +148,17 @@
     }
     
     #main-question {
-    font-size: 20px;
-}
+      font-size: 20px;
+    }
+    
+    #sorting_brand {
+      position: fixed;
+      left: 5px;
+      top: 0px;
+      margin: 10px; 
+      color: lightgray;
+    }  
+    
   </style>
 </head>
 
@@ -167,7 +176,7 @@
     </div>
     <div id="sort-stage" class="sort-stage" style="display: none;">
       <div class="displayables">
-        <h1>BattleSort</h1>
+        <h1 id="sort-stage-title">BattleSort</h1>
         <p id="main-question" class="lead">Which of these items is more <span style="font-weight: bold; background-color: yellow;"
             id="comparison">important?</span></p>
       </div>

--- a/index.html
+++ b/index.html
@@ -50,10 +50,16 @@
       font-size: 15px;
       font-family: 'Roboto', sans-serif;
       cursor: pointer;
+      border-radius: 5px;
+      border-width: 0px;
     }
 
     button:active {
       background-color: #fff5dd;
+    }
+    
+    button:focus {
+      outline: 0;
     }
 
     button.comparison-button {

--- a/index.html
+++ b/index.html
@@ -118,7 +118,10 @@
       display: flex;
       justify-content: center;
       align-items: center;
-      margin: 0;
+      margin: 5px;
+      position: fixed;
+      left: 10px;
+      bottom: 10px;
     }
 
     svg:hover {
@@ -135,11 +138,18 @@
       margin-top: 30px;
       color: gray;
       font-size: 13px;
+      position: fixed;
+      right: 10px;
+      bottom: 10px;
     }
 
     span.shortcuts-title {
       font-weight: bold;
     }
+    
+    #main-question {
+    font-size: 20px;
+}
   </style>
 </head>
 
@@ -158,8 +168,8 @@
     <div id="sort-stage" class="sort-stage" style="display: none;">
       <div class="displayables">
         <h1>BattleSort</h1>
-        <p id="main-question" class="lead">Which of these items is <span style="font-weight: bold; background-color: yellow;"
-            id="comparison">greater?</span></p>
+        <p id="main-question" class="lead">Which of these items is more <span style="font-weight: bold; background-color: yellow;"
+            id="comparison">important?</span></p>
       </div>
       <div class="row">
         <div class="col">

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
       font-size: 20px;
     }
     
-    #sorting_brand {
+    #sort-stage-title {
       position: fixed;
       left: 5px;
       top: 0px;

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -172,7 +172,7 @@ function swapDelineator() {
 
 window.onload = function () {
     const sortInput: HTMLTextAreaElement = document.getElementById('input') as HTMLTextAreaElement
-    sortInput.value = "Do dishes\nRake leaves\nVaccum, dust, sweep\nPet cat\nWalk dog\nBake a pie\nRead a book\nPlant a tree\nMake bed\nMop kitchen"
+    sortInput.value = "Do dishes\nRake leaves\nVacuum, dust, sweep\nPet cat\nWalk dog\nBake a pie\nRead a book"
 }
 
 window.setDebugInputValues = function () {


### PR DESCRIPTION
Improving usability of battlesort:

**During Sort**
- [x] Move shortcuts to lower right
- [x] Move undo to bottom left
- [x] Move Title to upper right, fade to light grey
- [x] New sorting question (till we have the option to select / DIY)
- [x] Make sorting question bigger
- [x] Make buttons bigger, so they hold longer list items better without becoming very different in size/shape
=> Future version should use flexbox to keep them the same size. Temp fix should be fine though.
- [x] Fix button borders onclick + slight styling changes
- [x] Disable blue border on focus
- [x] Shorten starting list